### PR TITLE
Avoid os.environ[item] = None, and related

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,8 +23,8 @@ package_dir =
 install_requires =
        julia>=0.2
        juliacall>=0.6.1
-       find_julia>=0.2.5
-       julia_project_basic>=0.1.4
+       find_julia>=0.2.6
+       julia_project_basic>=0.1.5
 
 [options.packages.find]
 where = src

--- a/src/julia_project/__init__.py
+++ b/src/julia_project/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.22"
+__version__ = "0.1.23"
 
 import os
 import sys
@@ -7,8 +7,8 @@ import shutil
 from ._julia_project import JuliaProject
 
 os.environ["PYTHON_JULIACALL_NOINIT"] = "yes"
-os.environ["JULIA_PYTHONCALL_EXE"] = sys.executable or '' # When does the latter occur?
-os.environ['JULIA_PYTHONCALL_LIBPTR'] = str(ctypes.pythonapi._handle)
+os.environ["JULIA_PYTHONCALL_EXE"] = sys.executable or ''
+os.environ['JULIA_PYTHONCALL_LIBPTR'] = str(ctypes.pythonapi._handle) or ''
 os.environ['PYTHON'] = shutil.which("python") or ''
 
 # This is only for debugging

--- a/src/julia_project/_julia_project.py
+++ b/src/julia_project/_julia_project.py
@@ -115,7 +115,7 @@ class JuliaProject:
         self._init_flags = {"initialized": False, "initializing": False, "disabled": False}
         self._post_init_hook = post_init_hook
         self._pre_instantiate_cmds = pre_instantiate_cmds
-        os.environ['PYCALL_JL_RUNTIME_PYTHON'] = shutil.which("python")
+        os.environ['PYCALL_JL_RUNTIME_PYTHON'] = shutil.which("python") or ''
         self.version_spec = version_spec
         self.strict_version = strict_version
         if calljulia is None:
@@ -145,6 +145,7 @@ class JuliaProject:
     def _set_project_path(self):
         self.project_path = os.path.join(_get_parent_project_path(), self.name + "-" + self.julia_version)
         os.makedirs(self.project_path, exist_ok = True)
+        assert self.project_path is not None
         os.environ["JULIA_PROJECT"] = self.project_path
         self.logger.info(f'os.environ["JULIA_PROJECT"] = {self.project_path}')
         utils.update_copy(self._in_package_dir("Project.toml"), self._in_project_dir("Project.toml"))
@@ -381,6 +382,7 @@ compatible with package that created this instance of JuliaProject.
             )
 
         if self.questions.results['depot'] is True:
+            assert possible_depot_path is not None
             os.environ["JULIA_DEPOT_PATH"] = possible_depot_path
             self.logger.info(f"Using private depot '{possible_depot_path}'")
         else:

--- a/src/julia_project/julia_system_image.py
+++ b/src/julia_project/julia_system_image.py
@@ -88,6 +88,7 @@ class JuliaSystemImage:
         for _file in [self._in_sys_image_dir("Manifest.toml"), self._in_sys_image_dir("JuliaManifest.toml")]:
             utils.maybe_remove(_file)
         Main.eval('ENV["PYCALL_JL_RUNTIME_PYTHON"] = Sys.which("python")')
+        assert isinstance(self.sys_image_dir, str)
         Pkg.activate(self.sys_image_dir)
         os.environ["JULIA_PROJECT"] = self.sys_image_dir
         pycall_loaded = Main.is_loaded("PyCall")

--- a/src/julia_project/juliacall.py
+++ b/src/julia_project/juliacall.py
@@ -20,8 +20,8 @@ LOGGER.info("importing julia_project/juliacall")
 
 
 def load_libjulia(julia_path,
-         project_path=None,
-         system_image=None):
+                  project_path,
+                  system_image=None):
     # Find the Julia executable and project
     CONFIG['exepath'] = exepath = julia_path # juliapkg.executable()
     CONFIG['project'] = project = project_path # juliapkg.project()
@@ -39,6 +39,7 @@ def load_libjulia(julia_path,
     julia_toplevel = os.path.dirname(os.path.dirname(libjulia_path))
     bindir = os.path.realpath(os.path.join(julia_toplevel, "bin"))
 
+    assert project is not None
     try:
         os.chdir(os.path.dirname(libjulia_path))
         CONFIG['lib'] = libjulia = ctypes.PyDLL(libjulia_path, ctypes.RTLD_GLOBAL) # <-- avoids segfault
@@ -167,9 +168,10 @@ class JuliaCall(CallJulia):
                 system_image = None
             libjulia, libjulia_path, bindir = load_libjulia(
                 self.julia_path,
-                project_path=self.project_path,
+                self.project_path,
                 system_image=system_image
             )
+            assert isinstance(self.project_path, str)
             init_pythoncall(libjulia, self.project_path)
             self.libjulia = lib.LibJulia(libjulia, libjulia_path, bindir)
             self._is_initialized = True


### PR DESCRIPTION
* I use some asserts and sometimes detect when the RHS is None
 and use '' instead.

* Bump dep versions and version